### PR TITLE
Fix incorrect tooltip example link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ tests: testpy testjs ## run the tests
 # Linting #
 ###########
 lintpy:  ## Black/flake8 python
-	python -m ruff ipydagred3 setup.py
+	python -m ruff format --check ipydagred3 setup.py
+	python -m ruff check ipydagred3 setup.py
 
 lintjs:  ## ESlint javascript
 	cd js; yarn lint
@@ -36,6 +37,7 @@ lintjs:  ## ESlint javascript
 lint: lintpy lintjs  ## run linter
 
 fixpy:  ## Black python
+	python -m ruff check --fix ipydagred3 setup.py
 	python -m ruff format ipydagred3 setup.py
 
 fixjs:  ## ESlint Autofix JS

--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ Network example from the first gif
 [Network Example](https://github.com/timkpaine/ipydagred3/tree/main/docs/examples/example.ipynb)
 
 Tooltip Example from the second gif
-[Tooltip Example](https://github.com/timkpaine/ipydagred3/tree/main/docs/examples/example.ipynb)
+[Tooltip Example](https://github.com/timkpaine/ipydagred3/tree/main/docs/examples/tooltip.ipynb)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,5 @@ build_cmd = "build"
 [tool.ruff]
 line-length = 120
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]


### PR DESCRIPTION
Just a small README fix: both example links are the same, while the second one should point to the tooltip example. Confused me for a moment.